### PR TITLE
Install setuptools

### DIFF
--- a/addon-dev/Dockerfile
+++ b/addon-dev/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache python3 py3-pip git && \
     python3 -m pip install --upgrade pip && \
     pip3 install pyyaml && \
     pip3 install tinydb && \
+    pip3 install setuptools && \
     pip3 install paho-mqtt==1.6.1 && \
     pip3 install git+https://github.com/mak-gitdev/enocean.git && \
     git clone -b master --single-branch --depth 1 https://github.com/embyt/enocean-mqtt.git && \

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache python3 py3-pip git && \
     python3 -m pip install --upgrade pip && \
     pip3 install pyyaml && \
     pip3 install tinydb && \
+    pip3 install setuptools && \
     pip3 install git+https://github.com/mak-gitdev/enocean.git && \
     git clone https://github.com/embyt/enocean-mqtt.git && \
     cd enocean-mqtt && python3 setup.py develop && cd .. && \


### PR DESCRIPTION
Hi, thank you for that great HA addon! 

Recent installations of the addon failed because of a missing dependency to `setuptools` ( see https://github.com/mak-gitdev/HA_enoceanmqtt/issues/146).
Not sure if it the best approach to tackle the problem, but just installing `setuptools` up front solved the problem for me.