### PR TITLE
Change to new HA add-on convention

### DIFF
--- a/addon-dev/Dockerfile
+++ b/addon-dev/Dockerfile
@@ -1,5 +1,4 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 ARG BUILD_VERSION
 


### PR DESCRIPTION
HA add-ons (Supervisor ≥ 2026.04.0) no longer support $BUILD_FROM arg